### PR TITLE
fix: Cannot find preset's package (github>shinGangan/renovate-config/configs/linters)

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -3,9 +3,8 @@
   "extends": [
     "@nuxtjs",
     "github>shinGangan/renovate-config",
-    "github>shinGangan/renovate-config//configs/linters",
-    "github>shinGangan/renovate-config//configs/sb",
-    ":dependencyDashboard",
-    "schedule:weekly"
+    "github>shinGangan/renovate-config//configs/nuxt/test-utils",
+    "github>shinGangan/renovate-config//configs/lint/linters",
+    "github>shinGangan/renovate-config//configs/sb"
   ]
 }


### PR DESCRIPTION
## Issue

closed #32 .

## Context

- [x] shinGangan/renovate-config#43 で実施したリファクタリング影響の不具合
- [x] `shinGangan/renovate-config//configs/nuxt/test-utils`を合わせて追加しました
  - 本当はPR分けた方がいい(今回は吸収した)
