### PR TITLE
fix(renovate): fix Nuxt extends in renovate config.

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "@nuxtjs",
+    "github>nuxt/renovate-config-nuxt",
     "github>shinGangan/renovate-config",
     "github>shinGangan/renovate-config//configs/nuxt/test-utils",
     "github>shinGangan/renovate-config//configs/lint/linters",


### PR DESCRIPTION
## Issue

resolved shinGangan/nuxt-config-website#24, shinGangan/nuxt-config-website#25 .
related #20 .

## Context

- [x] fix renovate warning

```
WARN: Using npm packages for Renovate presets is now deprecated. Please migrate to repository-based presets instead.
```

